### PR TITLE
Add meta robots noindex to gpgc_redirect.html

### DIFF
--- a/public/html/gpgc_redirect.html
+++ b/public/html/gpgc_redirect.html
@@ -1,6 +1,8 @@
 ---
 ---
-
+<head>
+<meta name="robots" content="noindex">
+</head>
 <script>
   var targetOrigin = "{{ site.url }}";
   var eventData = { type: "login" };


### PR DESCRIPTION
Search Engines dislike pages without content.